### PR TITLE
Run tomcat as non-root user

### DIFF
--- a/2.15.3/Dockerfile
+++ b/2.15.3/Dockerfile
@@ -1,10 +1,11 @@
 FROM tomcat:9-jdk11
 
-MAINTAINER Oscar Fonts <oscar.fonts@geomati.co>
+LABEL maintainer="Oscar Fonts <oscar.fonts@geomati.co>"
 
 ENV GEOSERVER_VERSION 2.15.3
 ENV GEOSERVER_DATA_DIR /var/local/geoserver
 ENV GEOSERVER_INSTALL_DIR /usr/local/geoserver
+ENV GEOSERVER_EXT_DIR /var/local/geoserver-exts
 
 # Uncomment to use APT cache (requires apt-cacher-ng on host)
 #RUN echo "Acquire::http { Proxy \"http://`/sbin/ip route|awk '/default/ { print $3 }'`:3142\"; };" > /etc/apt/apt.conf.d/71-apt-cacher-ng
@@ -51,7 +52,15 @@ ENV CATALINA_OPTS "-server -Djava.awt.headless=true \
 	-Xms768m -Xmx1560m -XX:+UseConcMarkSweepGC -XX:NewSize=48m \
 	-DGEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR}"
 
+# Create tomcat user to avoid root access. 
+RUN addgroup --gid 1099 tomcat && useradd -m -u 1099 -g tomcat tomcat \
+    && chown -R tomcat:tomcat . \
+    && chown -R tomcat:tomcat ${GEOSERVER_DATA_DIR} \
+    && chown -R tomcat:tomcat ${GEOSERVER_INSTALL_DIR}
+
 ADD start.sh /usr/local/bin/start.sh
-CMD start.sh
+ENTRYPOINT [ "start.sh" ]
+
+VOLUME ["${GEOSERVER_DATA_DIR}", "${GEOSERVER_EXT_DIR}"]
 
 EXPOSE 8080

--- a/2.15.3/start.sh
+++ b/2.15.3/start.sh
@@ -1,7 +1,23 @@
 #!/bin/bash
-for ext in `ls -d /var/local/geoserver-exts/*/`; do
-  cp "${ext}"*.jar /usr/local/geoserver/WEB-INF/lib
+
+if [ -n "${CUSTOM_UID}" ];then
+  echo "Using custom UID ${CUSTOM_UID}."
+  usermod -u ${CUSTOM_UID} tomcat
+  find / -user 1099 -exec chown -h tomcat {} \; 
+fi
+
+if [ -n "${CUSTOM_GID}" ];then
+  echo "Using custom GID ${CUSTOM_GID}."
+  groupmod -g ${CUSTOM_GID} tomcat
+  find / -group 1099 -exec chgrp -h tomcat {} \;
+fi
+
+#We need this line to ensure that data has the correct rights
+chown -R tomcat:tomcat ${GEOSERVER_DATA_DIR} 
+chown -R tomcat:tomcat ${GEOSERVER_EXT_DIR}
+
+for ext in `ls -d "${GEOSERVER_EXT_DIR}"/*/`; do
+  su tomcat -c "cp "${ext}"*.jar /usr/local/geoserver/WEB-INF/lib"
 done
 
-catalina.sh run
-
+su tomcat -c "/usr/local/tomcat/bin/catalina.sh run"

--- a/2.16.0/Dockerfile
+++ b/2.16.0/Dockerfile
@@ -1,10 +1,11 @@
 FROM tomcat:9-jdk11
 
-MAINTAINER Oscar Fonts <oscar.fonts@geomati.co>
+LABEL maintainer="Oscar Fonts <oscar.fonts@geomati.co>"
 
 ENV GEOSERVER_VERSION 2.16.0
 ENV GEOSERVER_DATA_DIR /var/local/geoserver
 ENV GEOSERVER_INSTALL_DIR /usr/local/geoserver
+ENV GEOSERVER_EXT_DIR /var/local/geoserver-exts
 
 # Uncomment to use APT cache (requires apt-cacher-ng on host)
 #RUN echo "Acquire::http { Proxy \"http://`/sbin/ip route|awk '/default/ { print $3 }'`:3142\"; };" > /etc/apt/apt.conf.d/71-apt-cacher-ng
@@ -19,12 +20,12 @@ RUN set -x \
 # GeoServer
 ADD conf/geoserver.xml /usr/local/tomcat/conf/Catalina/localhost/geoserver.xml
 RUN mkdir ${GEOSERVER_DATA_DIR} \
-	&& mkdir ${GEOSERVER_INSTALL_DIR} \
+    && mkdir ${GEOSERVER_INSTALL_DIR} \
 	&& cd ${GEOSERVER_INSTALL_DIR} \
 	&& wget http://sourceforge.net/projects/geoserver/files/GeoServer/${GEOSERVER_VERSION}/geoserver-${GEOSERVER_VERSION}-war.zip \
 	&& unzip geoserver-${GEOSERVER_VERSION}-war.zip \
 	&& unzip geoserver.war \
-	&& mv data/* ${GEOSERVER_DATA_DIR} \
+    && mv data/* ${GEOSERVER_DATA_DIR} \
 	&& rm -rf geoserver-${GEOSERVER_VERSION}-war.zip geoserver.war target *.txt
 
 # Enable CORS
@@ -51,7 +52,15 @@ ENV CATALINA_OPTS "-server -Djava.awt.headless=true \
 	-Xms768m -Xmx1560m -XX:+UseConcMarkSweepGC -XX:NewSize=48m \
 	-DGEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR}"
 
+# Create tomcat user to avoid root access. 
+RUN addgroup --gid 1099 tomcat && useradd -m -u 1099 -g tomcat tomcat \
+    && chown -R tomcat:tomcat . \
+    && chown -R tomcat:tomcat ${GEOSERVER_DATA_DIR} \
+    && chown -R tomcat:tomcat ${GEOSERVER_INSTALL_DIR}
+
 ADD start.sh /usr/local/bin/start.sh
-CMD start.sh
+ENTRYPOINT [ "start.sh" ]
+
+VOLUME ["${GEOSERVER_DATA_DIR}", "${GEOSERVER_EXT_DIR}"]
 
 EXPOSE 8080

--- a/2.16.0/start.sh
+++ b/2.16.0/start.sh
@@ -1,7 +1,23 @@
 #!/bin/bash
-for ext in `ls -d /var/local/geoserver-exts/*/`; do
-  cp "${ext}"*.jar /usr/local/geoserver/WEB-INF/lib
+
+if [ -n "${CUSTOM_UID}" ];then
+  echo "Using custom UID ${CUSTOM_UID}."
+  usermod -u ${CUSTOM_UID} tomcat
+  find / -user 1099 -exec chown -h tomcat {} \; 
+fi
+
+if [ -n "${CUSTOM_GID}" ];then
+  echo "Using custom GID ${CUSTOM_GID}."
+  groupmod -g ${CUSTOM_GID} tomcat
+  find / -group 1099 -exec chgrp -h tomcat {} \;
+fi
+
+#We need this line to ensure that data has the correct rights
+chown -R tomcat:tomcat ${GEOSERVER_DATA_DIR} 
+chown -R tomcat:tomcat ${GEOSERVER_EXT_DIR}
+
+for ext in `ls -d "${GEOSERVER_EXT_DIR}"/*/`; do
+  su tomcat -c "cp "${ext}"*.jar /usr/local/geoserver/WEB-INF/lib"
 done
 
-catalina.sh run
-
+su tomcat -c "/usr/local/tomcat/bin/catalina.sh run"

--- a/h2-vector/Dockerfile
+++ b/h2-vector/Dockerfile
@@ -1,6 +1,6 @@
 FROM oscarfonts/geoserver:2.16.0
 
-MAINTAINER Oscar Fonts <oscar.fonts@geomati.co>
+LABEL maintainer="Oscar Fonts <oscar.fonts@geomati.co>"
 
 ENV GEOSERVER_VERSION 2.16.0
 ENV GEOSERVER_INSTALL_DIR /usr/local/geoserver

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -1,5 +1,6 @@
 FROM oscarfonts/geoserver:2.16.0
-MAINTAINER Oscar Fonts <oscar.fonts@geomati.co>
+
+LABEL maintainer="Oscar Fonts <oscar.fonts@geomati.co>"
 
 ENV GEOSERVER_VERSION 2.16.0
 


### PR DESCRIPTION
By default, it create a user `tomcat` and group `tomcatusers` with uid `1099`.

We can set env `CUSTOM_UID` at container creation. It allow us to use the same uid on the container and the host, and have the same permisions on datadir.

Example usage:

```bash
docker run --rm -p 8080:8080 -e CUSTOM_UID=1000 -v ${PWD}/geoserver:/var/local/geoserver  oscarfonts/geoserver:2.16.0
```