### PR TITLE
New stable version 2.17.0

### DIFF
--- a/2.17.0/Dockerfile
+++ b/2.17.0/Dockerfile
@@ -1,0 +1,66 @@
+FROM tomcat:9-jdk11
+
+LABEL maintainer="Oscar Fonts <oscar.fonts@geomati.co>"
+
+ENV GEOSERVER_VERSION 2.17.0
+ENV GEOSERVER_DATA_DIR /var/local/geoserver
+ENV GEOSERVER_INSTALL_DIR /usr/local/geoserver
+ENV GEOSERVER_EXT_DIR /var/local/geoserver-exts
+
+# Uncomment to use APT cache (requires apt-cacher-ng on host)
+#RUN echo "Acquire::http { Proxy \"http://`/sbin/ip route|awk '/default/ { print $3 }'`:3142\"; };" > /etc/apt/apt.conf.d/71-apt-cacher-ng
+
+# Microsoft fonts
+RUN echo "deb http://httpredir.debian.org/debian stretch contrib" >> /etc/apt/sources.list
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -yq ttf-mscorefonts-installer \
+	&& rm -rf /var/lib/apt/lists/*
+
+# GeoServer
+ADD conf/geoserver.xml /usr/local/tomcat/conf/Catalina/localhost/geoserver.xml
+RUN mkdir ${GEOSERVER_DATA_DIR} \
+    && mkdir ${GEOSERVER_INSTALL_DIR} \
+	&& cd ${GEOSERVER_INSTALL_DIR} \
+	&& wget http://sourceforge.net/projects/geoserver/files/GeoServer/${GEOSERVER_VERSION}/geoserver-${GEOSERVER_VERSION}-war.zip \
+	&& unzip geoserver-${GEOSERVER_VERSION}-war.zip \
+	&& unzip geoserver.war \
+    && mv data/* ${GEOSERVER_DATA_DIR} \
+	&& rm -rf geoserver-${GEOSERVER_VERSION}-war.zip geoserver.war target *.txt
+
+# Enable CORS
+RUN sed -i '\:</web-app>:i\
+<filter>\n\
+    <filter-name>CorsFilter</filter-name>\n\
+    <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>\n\
+    <init-param>\n\
+        <param-name>cors.allowed.origins</param-name>\n\
+        <param-value>*</param-value>\n\
+    </init-param>\n\
+    <init-param>\n\
+        <param-name>cors.allowed.methods</param-name>\n\
+        <param-value>GET,POST,HEAD,OPTIONS,PUT</param-value>\n\
+    </init-param>\n\
+</filter>\n\
+<filter-mapping>\n\
+    <filter-name>CorsFilter</filter-name>\n\
+    <url-pattern>/*</url-pattern>\n\
+</filter-mapping>' ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml
+
+# Tomcat environment
+ENV CATALINA_OPTS "-server -Djava.awt.headless=true \
+	-Xms768m -Xmx1560m -XX:+UseConcMarkSweepGC -XX:NewSize=48m \
+	-DGEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR}"
+
+# Create tomcat user to avoid root access. 
+RUN addgroup --gid 1099 tomcat && useradd -m -u 1099 -g tomcat tomcat \
+    && chown -R tomcat:tomcat . \
+    && chown -R tomcat:tomcat ${GEOSERVER_DATA_DIR} \
+    && chown -R tomcat:tomcat ${GEOSERVER_INSTALL_DIR}
+
+ADD start.sh /usr/local/bin/start.sh
+ENTRYPOINT [ "/bin/sh", "/usr/local/bin/start.sh"]
+
+VOLUME ["${GEOSERVER_DATA_DIR}", "${GEOSERVER_EXT_DIR}"]
+
+EXPOSE 8080

--- a/2.17.0/conf/ROOT.xml
+++ b/2.17.0/conf/ROOT.xml
@@ -1,0 +1,1 @@
+<Context path="/" docBase="/usr/local/geoserver"></Context>

--- a/2.17.0/conf/geoserver.xml
+++ b/2.17.0/conf/geoserver.xml
@@ -1,0 +1,1 @@
+<Context path="/geoserver" docBase="/usr/local/geoserver"></Context>

--- a/2.17.0/start.sh
+++ b/2.17.0/start.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ -n "${CUSTOM_UID}" ];then
+  echo "Using custom UID ${CUSTOM_UID}."
+  usermod -u ${CUSTOM_UID} tomcat
+  find / -user 1099 -exec chown -h tomcat {} \; 
+fi
+
+if [ -n "${CUSTOM_GID}" ];then
+  echo "Using custom GID ${CUSTOM_GID}."
+  groupmod -g ${CUSTOM_GID} tomcat
+  find / -group 1099 -exec chgrp -h tomcat {} \;
+fi
+
+#We need this line to ensure that data has the correct rights
+chown -R tomcat:tomcat ${GEOSERVER_DATA_DIR} 
+chown -R tomcat:tomcat ${GEOSERVER_EXT_DIR}
+
+for ext in `ls -d "${GEOSERVER_EXT_DIR}"/*/`; do
+  su tomcat -c "cp "${ext}"*.jar /usr/local/geoserver/WEB-INF/lib"
+done
+
+su tomcat -c "/usr/local/tomcat/bin/catalina.sh run"

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Dockerized GeoServer.
 
 Latest versions with [automated builds](https://hub.docker.com/r/oscarfonts/geoserver/) available on [docker registry](https://registry.hub.docker.com/):
 
-* [`latest`, `2.16.1` (*2.16.1/Dockerfile*)](https://github.com/oscarfonts/docker-geoserver/blob/master/2.16.1/Dockerfile)
-* [`2.15.3` (*2.15.3/Dockerfile*)](https://github.com/oscarfonts/docker-geoserver/blob/master/2.15.3/Dockerfile)
+* [`latest`, `2.17.0` (*2.17.0/Dockerfile*)](https://github.com/oscarfonts/docker-geoserver/blob/master/2.17.0/Dockerfile)
+* [`2.16.2` (*2.16.2/Dockerfile*)](https://github.com/oscarfonts/docker-geoserver/blob/master/2.16.2/Dockerfile)
+* [`2.15.4` (*2.15.4/Dockerfile*)](https://github.com/oscarfonts/docker-geoserver/blob/master/2.15.4/Dockerfile)
 
 Other experimental dockerfiles (not automated build):
 
@@ -71,4 +72,4 @@ It is also possible to configure the context path by providing a Catalina config
 docker run -d -p 8080:8080 -v ${PWD}/config_dir:/usr/local/tomcat/conf/Catalina/localhost oscarfonts/geoserver
 ```
 
-See some [examples](https://github.com/oscarfonts/docker-geoserver/tree/master/2.16.1/conf).
+See some [examples](https://github.com/oscarfonts/docker-geoserver/tree/master/2.17.0/conf).

--- a/h2-vector/Dockerfile
+++ b/h2-vector/Dockerfile
@@ -1,8 +1,8 @@
-FROM oscarfonts/geoserver:2.16.2
+FROM oscarfonts/geoserver:2.17.0
 
 LABEL maintainer="Oscar Fonts <oscar.fonts@geomati.co>"
 
-ENV GEOSERVER_VERSION 2.16.2
+ENV GEOSERVER_VERSION 2.17.0
 ENV GEOSERVER_INSTALL_DIR /usr/local/geoserver
 
 WORKDIR ${GEOSERVER_INSTALL_DIR}/WEB-INF/lib

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -1,8 +1,8 @@
-FROM oscarfonts/geoserver:2.16.2
+FROM oscarfonts/geoserver:2.17.0
 
 LABEL maintainer="Oscar Fonts <oscar.fonts@geomati.co>"
 
-ENV GEOSERVER_VERSION 2.16.2
+ENV GEOSERVER_VERSION 2.17.0
 
 WORKDIR /usr/local/tomcat/webapps/geoserver/WEB-INF/lib
 


### PR DESCRIPTION
Released 2.17.0 with new features and bug fixes as usual, between them significant improvements have been made to GeoWebCache and its integration with GeoServer.

Info:
http://blog.geoserver.org/2020/04/21/geoserver-2-17-0-released/

