### PR TITLE
Enable CORS configuration with environment variables

### DIFF
--- a/2.18.7/Dockerfile
+++ b/2.18.7/Dockerfile
@@ -31,25 +31,6 @@ RUN mkdir ${GEOSERVER_DATA_DIR} \
     && mv data/* ${GEOSERVER_DATA_DIR} \
 	&& rm -rf geoserver-${GEOSERVER_VERSION}-war.zip geoserver.war target *.txt
 
-# Enable CORS
-RUN sed -i '\:</web-app>:i\
-<filter>\n\
-    <filter-name>CorsFilter</filter-name>\n\
-    <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>\n\
-    <init-param>\n\
-        <param-name>cors.allowed.origins</param-name>\n\
-        <param-value>*</param-value>\n\
-    </init-param>\n\
-    <init-param>\n\
-        <param-name>cors.allowed.methods</param-name>\n\
-        <param-value>GET,POST,HEAD,OPTIONS,PUT</param-value>\n\
-    </init-param>\n\
-</filter>\n\
-<filter-mapping>\n\
-    <filter-name>CorsFilter</filter-name>\n\
-    <url-pattern>/*</url-pattern>\n\
-</filter-mapping>' ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml
-
 # Tomcat environment
 ENV CATALINA_OPTS "-server -Djava.awt.headless=true \
 	-Xms768m -Xmx1560m -XX:+UseConcMarkSweepGC -XX:NewSize=48m \

--- a/2.18.7/start.sh
+++ b/2.18.7/start.sh
@@ -1,5 +1,30 @@
 #!/bin/sh
 
+# Enable CORS
+if [ "${GEOSERVER_CORS_ENABLED}" != "false" ]; then
+  sed -i "\:</web-app>:i\
+    <filter>\n\
+      <filter-name>cross-origin</filter-name>\n\
+      <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>\n\
+      <init-param>\n\
+        <param-name>cors.allowed.origins</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_ORIGINS:-*}</param-value>\n\
+      </init-param>\n\
+      <init-param>\n\
+        <param-name>cors.allowed.methods</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_METHODS:-GET,POST,PUT,DELETE,HEAD,OPTIONS}</param-value>\n\
+      </init-param>\n\
+      <init-param>\n\
+      <param-name>cors.allowed.headers</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_HEADERS:-*}</param-value>\n\
+      </init-param>\n\
+    </filter>\n\
+    <filter-mapping>\n\
+      <filter-name>cross-origin</filter-name>\n\
+      <url-pattern>${GEOSERVER_CORS_CROSS_ORIGIN:-/*}</url-pattern>\n\
+    </filter-mapping>" ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml
+fi
+
 if [ -n "${CUSTOM_UID}" ]; then
   echo "Using custom UID ${CUSTOM_UID}."
   usermod -u ${CUSTOM_UID} tomcat

--- a/2.19.7/Dockerfile
+++ b/2.19.7/Dockerfile
@@ -31,25 +31,6 @@ RUN mkdir ${GEOSERVER_DATA_DIR} \
     && mv data/* ${GEOSERVER_DATA_DIR} \
 	&& rm -rf geoserver-${GEOSERVER_VERSION}-war.zip geoserver.war target *.txt
 
-# Enable CORS
-RUN sed -i '\:</web-app>:i\
-<filter>\n\
-    <filter-name>CorsFilter</filter-name>\n\
-    <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>\n\
-    <init-param>\n\
-        <param-name>cors.allowed.origins</param-name>\n\
-        <param-value>*</param-value>\n\
-    </init-param>\n\
-    <init-param>\n\
-        <param-name>cors.allowed.methods</param-name>\n\
-        <param-value>GET,POST,HEAD,OPTIONS,PUT</param-value>\n\
-    </init-param>\n\
-</filter>\n\
-<filter-mapping>\n\
-    <filter-name>CorsFilter</filter-name>\n\
-    <url-pattern>/*</url-pattern>\n\
-</filter-mapping>' ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml
-
 # Tomcat environment
 ENV CATALINA_OPTS "-server -Djava.awt.headless=true \
 	-Xms768m -Xmx1560m -XX:+UseConcMarkSweepGC -XX:NewSize=48m \

--- a/2.19.7/start.sh
+++ b/2.19.7/start.sh
@@ -1,5 +1,30 @@
 #!/bin/sh
 
+# Enable CORS
+if [ "${GEOSERVER_CORS_ENABLED}" != "false" ]; then
+  sed -i "\:</web-app>:i\
+    <filter>\n\
+      <filter-name>cross-origin</filter-name>\n\
+      <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>\n\
+      <init-param>\n\
+        <param-name>cors.allowed.origins</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_ORIGINS:-*}</param-value>\n\
+      </init-param>\n\
+      <init-param>\n\
+        <param-name>cors.allowed.methods</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_METHODS:-GET,POST,PUT,DELETE,HEAD,OPTIONS}</param-value>\n\
+      </init-param>\n\
+      <init-param>\n\
+      <param-name>cors.allowed.headers</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_HEADERS:-*}</param-value>\n\
+      </init-param>\n\
+    </filter>\n\
+    <filter-mapping>\n\
+      <filter-name>cross-origin</filter-name>\n\
+      <url-pattern>${GEOSERVER_CORS_CROSS_ORIGIN:-/*}</url-pattern>\n\
+    </filter-mapping>" ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml
+fi
+
 if [ -n "${CUSTOM_UID}" ]; then
   echo "Using custom UID ${CUSTOM_UID}."
   usermod -u ${CUSTOM_UID} tomcat

--- a/2.20.7/Dockerfile
+++ b/2.20.7/Dockerfile
@@ -31,25 +31,6 @@ RUN mkdir ${GEOSERVER_DATA_DIR} \
     && mv data/* ${GEOSERVER_DATA_DIR} \
 	&& rm -rf geoserver-${GEOSERVER_VERSION}-war.zip geoserver.war target *.txt
 
-# Enable CORS
-RUN sed -i '\:</web-app>:i\
-<filter>\n\
-    <filter-name>CorsFilter</filter-name>\n\
-    <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>\n\
-    <init-param>\n\
-        <param-name>cors.allowed.origins</param-name>\n\
-        <param-value>*</param-value>\n\
-    </init-param>\n\
-    <init-param>\n\
-        <param-name>cors.allowed.methods</param-name>\n\
-        <param-value>GET,POST,HEAD,OPTIONS,PUT</param-value>\n\
-    </init-param>\n\
-</filter>\n\
-<filter-mapping>\n\
-    <filter-name>CorsFilter</filter-name>\n\
-    <url-pattern>/*</url-pattern>\n\
-</filter-mapping>' ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml
-
 # Tomcat environment
 ENV CATALINA_OPTS "-server -Djava.awt.headless=true \
 	-Xms768m -Xmx1560m -XX:+UseConcMarkSweepGC -XX:NewSize=48m \

--- a/2.20.7/start.sh
+++ b/2.20.7/start.sh
@@ -1,5 +1,30 @@
 #!/bin/sh
 
+# Enable CORS
+if [ "${GEOSERVER_CORS_ENABLED}" != "false" ]; then
+  sed -i "\:</web-app>:i\
+    <filter>\n\
+      <filter-name>cross-origin</filter-name>\n\
+      <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>\n\
+      <init-param>\n\
+        <param-name>cors.allowed.origins</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_ORIGINS:-*}</param-value>\n\
+      </init-param>\n\
+      <init-param>\n\
+        <param-name>cors.allowed.methods</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_METHODS:-GET,POST,PUT,DELETE,HEAD,OPTIONS}</param-value>\n\
+      </init-param>\n\
+      <init-param>\n\
+      <param-name>cors.allowed.headers</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_HEADERS:-*}</param-value>\n\
+      </init-param>\n\
+    </filter>\n\
+    <filter-mapping>\n\
+      <filter-name>cross-origin</filter-name>\n\
+      <url-pattern>${GEOSERVER_CORS_CROSS_ORIGIN:-/*}</url-pattern>\n\
+    </filter-mapping>" ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml
+fi
+
 if [ -n "${CUSTOM_UID}" ]; then
   echo "Using custom UID ${CUSTOM_UID}."
   usermod -u ${CUSTOM_UID} tomcat

--- a/2.21.5/Dockerfile
+++ b/2.21.5/Dockerfile
@@ -31,25 +31,6 @@ RUN mkdir ${GEOSERVER_DATA_DIR} \
     && mv data/* ${GEOSERVER_DATA_DIR} \
 	&& rm -rf geoserver-${GEOSERVER_VERSION}-war.zip geoserver.war target *.txt
 
-# Enable CORS
-RUN sed -i '\:</web-app>:i\
-<filter>\n\
-    <filter-name>CorsFilter</filter-name>\n\
-    <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>\n\
-    <init-param>\n\
-        <param-name>cors.allowed.origins</param-name>\n\
-        <param-value>*</param-value>\n\
-    </init-param>\n\
-    <init-param>\n\
-        <param-name>cors.allowed.methods</param-name>\n\
-        <param-value>GET,POST,HEAD,OPTIONS,PUT</param-value>\n\
-    </init-param>\n\
-</filter>\n\
-<filter-mapping>\n\
-    <filter-name>CorsFilter</filter-name>\n\
-    <url-pattern>/*</url-pattern>\n\
-</filter-mapping>' ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml
-
 # Tomcat environment
 ENV CATALINA_OPTS "-server -Djava.awt.headless=true \
 	-Xms768m -Xmx1560m -XX:+UseConcMarkSweepGC -XX:NewSize=48m \

--- a/2.21.5/start.sh
+++ b/2.21.5/start.sh
@@ -1,5 +1,30 @@
 #!/bin/sh
 
+# Enable CORS
+if [ "${GEOSERVER_CORS_ENABLED}" != "false" ]; then
+  sed -i "\:</web-app>:i\
+    <filter>\n\
+      <filter-name>cross-origin</filter-name>\n\
+      <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>\n\
+      <init-param>\n\
+        <param-name>cors.allowed.origins</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_ORIGINS:-*}</param-value>\n\
+      </init-param>\n\
+      <init-param>\n\
+        <param-name>cors.allowed.methods</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_METHODS:-GET,POST,PUT,DELETE,HEAD,OPTIONS}</param-value>\n\
+      </init-param>\n\
+      <init-param>\n\
+      <param-name>cors.allowed.headers</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_HEADERS:-*}</param-value>\n\
+      </init-param>\n\
+    </filter>\n\
+    <filter-mapping>\n\
+      <filter-name>cross-origin</filter-name>\n\
+      <url-pattern>${GEOSERVER_CORS_CROSS_ORIGIN:-/*}</url-pattern>\n\
+    </filter-mapping>" ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml
+fi
+
 if [ -n "${CUSTOM_UID}" ]; then
   echo "Using custom UID ${CUSTOM_UID}."
   usermod -u ${CUSTOM_UID} tomcat

--- a/2.22.5/Dockerfile
+++ b/2.22.5/Dockerfile
@@ -31,25 +31,6 @@ RUN mkdir ${GEOSERVER_DATA_DIR} \
     && mv data/* ${GEOSERVER_DATA_DIR} \
 	&& rm -rf geoserver-${GEOSERVER_VERSION}-war.zip geoserver.war target *.txt
 
-# Enable CORS
-RUN sed -i '\:</web-app>:i\
-<filter>\n\
-    <filter-name>CorsFilter</filter-name>\n\
-    <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>\n\
-    <init-param>\n\
-        <param-name>cors.allowed.origins</param-name>\n\
-        <param-value>*</param-value>\n\
-    </init-param>\n\
-    <init-param>\n\
-        <param-name>cors.allowed.methods</param-name>\n\
-        <param-value>GET,POST,HEAD,OPTIONS,PUT</param-value>\n\
-    </init-param>\n\
-</filter>\n\
-<filter-mapping>\n\
-    <filter-name>CorsFilter</filter-name>\n\
-    <url-pattern>/*</url-pattern>\n\
-</filter-mapping>' ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml
-
 # Tomcat environment
 ENV CATALINA_OPTS "-server -Djava.awt.headless=true \
 	-Xms768m -Xmx1560m -XX:+UseConcMarkSweepGC -XX:NewSize=48m \

--- a/2.22.5/start.sh
+++ b/2.22.5/start.sh
@@ -1,5 +1,30 @@
 #!/bin/sh
 
+# Enable CORS
+if [ "${GEOSERVER_CORS_ENABLED}" != "false" ]; then
+  sed -i "\:</web-app>:i\
+    <filter>\n\
+      <filter-name>cross-origin</filter-name>\n\
+      <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>\n\
+      <init-param>\n\
+        <param-name>cors.allowed.origins</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_ORIGINS:-*}</param-value>\n\
+      </init-param>\n\
+      <init-param>\n\
+        <param-name>cors.allowed.methods</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_METHODS:-GET,POST,PUT,DELETE,HEAD,OPTIONS}</param-value>\n\
+      </init-param>\n\
+      <init-param>\n\
+      <param-name>cors.allowed.headers</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_HEADERS:-*}</param-value>\n\
+      </init-param>\n\
+    </filter>\n\
+    <filter-mapping>\n\
+      <filter-name>cross-origin</filter-name>\n\
+      <url-pattern>${GEOSERVER_CORS_CROSS_ORIGIN:-/*}</url-pattern>\n\
+    </filter-mapping>" ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml
+fi
+
 if [ -n "${CUSTOM_UID}" ]; then
   echo "Using custom UID ${CUSTOM_UID}."
   usermod -u ${CUSTOM_UID} tomcat

--- a/2.23.2/Dockerfile
+++ b/2.23.2/Dockerfile
@@ -31,29 +31,6 @@ RUN mkdir ${GEOSERVER_DATA_DIR} \
     && mv data/* ${GEOSERVER_DATA_DIR} \
 	&& rm -rf geoserver-${GEOSERVER_VERSION}-war.zip geoserver.war target *.txt
 
-# Enable CORS
-RUN sed -i '\:</web-app>:i\
-<filter>\n\
-  <filter-name>cross-origin</filter-name>\n\
-  <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>\n\
-  <init-param>\n\
-    <param-name>cors.allowed.origins</param-name>\n\
-    <param-value>*</param-value>\n\
-  </init-param>\n\
-  <init-param>\n\
-    <param-name>cors.allowed.methods</param-name>\n\
-    <param-value>GET,POST,PUT,DELETE,HEAD,OPTIONS</param-value>\n\
-  </init-param>\n\
-  <init-param>\n\
-  <param-name>cors.allowed.headers</param-name>\n\
-    <param-value>*</param-value>\n\
-  </init-param>\n\
-</filter>\n\
-<filter-mapping>\n\
-  <filter-name>cross-origin</filter-name>\n\
-  <url-pattern>/*</url-pattern>\n\
-</filter-mapping>' ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml
-
 # Tomcat environment
 ENV CATALINA_OPTS "-server -Djava.awt.headless=true \
 	-Xms128m -Xmx1560m -XX:NewSize=48m \

--- a/2.23.2/start.sh
+++ b/2.23.2/start.sh
@@ -1,5 +1,30 @@
 #!/bin/sh
 
+# Enable CORS
+if [ "${GEOSERVER_CORS_ENABLED}" != "false" ]; then
+  sed -i "\:</web-app>:i\
+    <filter>\n\
+      <filter-name>cross-origin</filter-name>\n\
+      <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>\n\
+      <init-param>\n\
+        <param-name>cors.allowed.origins</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_ORIGINS:-*}</param-value>\n\
+      </init-param>\n\
+      <init-param>\n\
+        <param-name>cors.allowed.methods</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_METHODS:-GET,POST,PUT,DELETE,HEAD,OPTIONS}</param-value>\n\
+      </init-param>\n\
+      <init-param>\n\
+      <param-name>cors.allowed.headers</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_HEADERS:-*}</param-value>\n\
+      </init-param>\n\
+    </filter>\n\
+    <filter-mapping>\n\
+      <filter-name>cross-origin</filter-name>\n\
+      <url-pattern>${GEOSERVER_CORS_CROSS_ORIGIN:-/*}</url-pattern>\n\
+    </filter-mapping>" ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml
+fi
+
 if [ -n "${CUSTOM_UID}" ]; then
   echo "Using custom UID ${CUSTOM_UID}."
   usermod -u ${CUSTOM_UID} tomcat

--- a/2.24.0/Dockerfile
+++ b/2.24.0/Dockerfile
@@ -31,29 +31,6 @@ RUN mkdir ${GEOSERVER_DATA_DIR} \
     && mv data/* ${GEOSERVER_DATA_DIR} \
 	&& rm -rf geoserver-${GEOSERVER_VERSION}-war.zip geoserver.war target *.txt
 
-# Enable CORS
-RUN sed -i '\:</web-app>:i\
-<filter>\n\
-  <filter-name>cross-origin</filter-name>\n\
-  <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>\n\
-  <init-param>\n\
-    <param-name>cors.allowed.origins</param-name>\n\
-    <param-value>*</param-value>\n\
-  </init-param>\n\
-  <init-param>\n\
-    <param-name>cors.allowed.methods</param-name>\n\
-    <param-value>GET,POST,PUT,DELETE,HEAD,OPTIONS</param-value>\n\
-  </init-param>\n\
-  <init-param>\n\
-  <param-name>cors.allowed.headers</param-name>\n\
-    <param-value>*</param-value>\n\
-  </init-param>\n\
-</filter>\n\
-<filter-mapping>\n\
-  <filter-name>cross-origin</filter-name>\n\
-  <url-pattern>/*</url-pattern>\n\
-</filter-mapping>' ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml
-
 # Tomcat environment
 ENV CATALINA_OPTS "-server -Djava.awt.headless=true \
 	-Xms128m -Xmx1560m -XX:NewSize=48m \

--- a/2.24.0/start.sh
+++ b/2.24.0/start.sh
@@ -1,5 +1,30 @@
 #!/bin/sh
 
+# Enable CORS
+if [ "${GEOSERVER_CORS_ENABLED}" != "false" ]; then
+  sed -i "\:</web-app>:i\
+    <filter>\n\
+      <filter-name>cross-origin</filter-name>\n\
+      <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>\n\
+      <init-param>\n\
+        <param-name>cors.allowed.origins</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_ORIGINS:-*}</param-value>\n\
+      </init-param>\n\
+      <init-param>\n\
+        <param-name>cors.allowed.methods</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_METHODS:-GET,POST,PUT,DELETE,HEAD,OPTIONS}</param-value>\n\
+      </init-param>\n\
+      <init-param>\n\
+      <param-name>cors.allowed.headers</param-name>\n\
+        <param-value>${GEOSERVER_CORS_ALLOWED_HEADERS:-*}</param-value>\n\
+      </init-param>\n\
+    </filter>\n\
+    <filter-mapping>\n\
+      <filter-name>cross-origin</filter-name>\n\
+      <url-pattern>${GEOSERVER_CORS_URL_PATTERN:-/*}</url-pattern>\n\
+    </filter-mapping>" ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml
+fi
+
 if [ -n "${CUSTOM_UID}" ]; then
   echo "Using custom UID ${CUSTOM_UID}."
   usermod -u ${CUSTOM_UID} tomcat

--- a/README.md
+++ b/README.md
@@ -88,3 +88,18 @@ docker run -d -p 8080:8080 -v ${PWD}/config_dir:/usr/local/tomcat/conf/Catalina/
 ```
 
 See some [examples](https://github.com/oscarfonts/docker-geoserver/tree/master/2.24.0/conf).
+
+### CORS
+
+CORS is configured automatically in the servlet web.xml filters. If you have another
+component in front that already takes care of it you can disable it with the environment variable
+`-e "GEOSERVER_CORS_ENABLED=false"`.
+
+It is also possible to fine tune it for specific origins, methods, etc. with the following variables:
+- `GEOSERVER_CORS_ALLOWED_ORIGINS` (cors.allowed.origins)
+- `GEOSERVER_CORS_ALLOWED_METHODS` (cors.allowed.methods)
+- `GEOSERVER_CORS_ALLOWED_HEADERS` (cors.allowed.headers)
+- `GEOSERVER_CORS_URL_PATTERN` (filter-mapping url-pattern)
+
+See [Tomcat documentation](https://tomcat.apache.org/tomcat-7.0-doc/config/filter.html#CORS_Filter)
+for more info.


### PR DESCRIPTION
Adding the CORS configuration to the `web.xml` file on startup instead of image build to be able to decide based on environment variables. Fixes #11 