### PR TITLE
Fix bug with CORS configuration on stop/start

### DIFF
--- a/2.18.7/start.sh
+++ b/2.18.7/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Enable CORS
-if [ "${GEOSERVER_CORS_ENABLED}" != "false" ]; then
+if [ "${GEOSERVER_CORS_ENABLED}" != "false" -a -z "$(grep "<filter-name>\s*cross-origin" ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml)" ]; then
   sed -i "\:</web-app>:i\
     <filter>\n\
       <filter-name>cross-origin</filter-name>\n\

--- a/2.19.7/start.sh
+++ b/2.19.7/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Enable CORS
-if [ "${GEOSERVER_CORS_ENABLED}" != "false" ]; then
+if [ "${GEOSERVER_CORS_ENABLED}" != "false" -a -z "$(grep "<filter-name>\s*cross-origin" ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml)" ]; then
   sed -i "\:</web-app>:i\
     <filter>\n\
       <filter-name>cross-origin</filter-name>\n\

--- a/2.20.7/start.sh
+++ b/2.20.7/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Enable CORS
-if [ "${GEOSERVER_CORS_ENABLED}" != "false" ]; then
+if [ "${GEOSERVER_CORS_ENABLED}" != "false" -a -z "$(grep "<filter-name>\s*cross-origin" ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml)" ]; then
   sed -i "\:</web-app>:i\
     <filter>\n\
       <filter-name>cross-origin</filter-name>\n\

--- a/2.21.5/start.sh
+++ b/2.21.5/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Enable CORS
-if [ "${GEOSERVER_CORS_ENABLED}" != "false" ]; then
+if [ "${GEOSERVER_CORS_ENABLED}" != "false" -a -z "$(grep "<filter-name>\s*cross-origin" ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml)" ]; then
   sed -i "\:</web-app>:i\
     <filter>\n\
       <filter-name>cross-origin</filter-name>\n\

--- a/2.22.5/start.sh
+++ b/2.22.5/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Enable CORS
-if [ "${GEOSERVER_CORS_ENABLED}" != "false" ]; then
+if [ "${GEOSERVER_CORS_ENABLED}" != "false" -a -z "$(grep "<filter-name>\s*cross-origin" ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml)" ]; then
   sed -i "\:</web-app>:i\
     <filter>\n\
       <filter-name>cross-origin</filter-name>\n\

--- a/2.23.2/start.sh
+++ b/2.23.2/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Enable CORS
-if [ "${GEOSERVER_CORS_ENABLED}" != "false" ]; then
+if [ "${GEOSERVER_CORS_ENABLED}" != "false" -a -z "$(grep "<filter-name>\s*cross-origin" ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml)" ]; then
   sed -i "\:</web-app>:i\
     <filter>\n\
       <filter-name>cross-origin</filter-name>\n\

--- a/2.24.0/start.sh
+++ b/2.24.0/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Enable CORS
-if [ "${GEOSERVER_CORS_ENABLED}" != "false" ]; then
+if [ "${GEOSERVER_CORS_ENABLED}" != "false" -a -z "$(grep "<filter-name>\s*cross-origin" ${GEOSERVER_INSTALL_DIR}/WEB-INF/web.xml)" ]; then
   sed -i "\:</web-app>:i\
     <filter>\n\
       <filter-name>cross-origin</filter-name>\n\


### PR DESCRIPTION
Currently, when running `docker stop ...` and `docker start ...` multiple times it adds the filter each time, resulting in:

```
org.xml.sax.SAXParseException; systemId: file:/usr/local/geoserver/WEB-INF/web.xml; lineNumber: 337; columnNumber: 14; Error at line [337] column [14]: [Duplicate filter name [cross-origin]]
```