### PR TITLE
Configures ubuntu user as default

### DIFF
--- a/2.23.6/Dockerfile
+++ b/2.23.6/Dockerfile
@@ -36,11 +36,10 @@ ENV CATALINA_OPTS "-server -Djava.awt.headless=true \
 	-Xms128m -Xmx1560m -XX:NewSize=48m \
 	-DGEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR}"
 
-# Create tomcat user to avoid root access. 
-RUN addgroup --gid 1099 tomcat && useradd -m -u 1099 -g tomcat tomcat \
-    && chown -R tomcat:tomcat . \
-    && chown -R tomcat:tomcat ${GEOSERVER_DATA_DIR} \
-    && chown -R tomcat:tomcat ${GEOSERVER_INSTALL_DIR}
+# Use default ubuntu user (1000:1000) to avoid root access.
+RUN chown -R ubuntu:ubuntu . \
+    && chown -R ubuntu:ubuntu ${GEOSERVER_DATA_DIR} \
+    && chown -R ubuntu:ubuntu ${GEOSERVER_INSTALL_DIR}
 
 # index.html is used for health check; ensure build fails early if not present
 RUN cat ${GEOSERVER_INSTALL_DIR}/index.html

--- a/2.23.6/start.sh
+++ b/2.23.6/start.sh
@@ -27,31 +27,41 @@ fi
 
 if [ -n "${CUSTOM_UID}" ]; then
   echo "Using custom UID ${CUSTOM_UID}."
-  usermod -u ${CUSTOM_UID} tomcat
-  find / -xdev -user 1099 -exec chown -h tomcat '{}' +
+  UBUNTU_UID=$(id -u "ubuntu" 2>/dev/null)
+  if [ "$UBUNTU_UID" -eq "$CUSTOM_UID" ]; then
+    echo "CUSTOM_UID already in use for ubuntu user. Nothing to do."
+  else
+    usermod -u ${CUSTOM_UID} ubuntu
+    find / -xdev -user 1000 -exec chown -h ubuntu '{}' +
+  fi
 fi
 
 if [ -n "${CUSTOM_GID}" ]; then
   echo "Using custom GID ${CUSTOM_GID}."
-  groupmod -g ${CUSTOM_GID} tomcat
-  find / -xdev -group 1099 -exec chgrp -h tomcat '{}' +
+  UBUNTU_GID=$(id -g "ubuntu" 2>/dev/null)
+  if [ "$UBUNTU_GID" -eq "$CUSTOM_GID" ]; then
+    echo "CUSTOM_GID already in use for ubuntu user. Nothing to do."
+  else
+    groupmod -g ${CUSTOM_GID} ubuntu
+    find / -xdev -group 1000 -exec chgrp -h ubuntu '{}' +
+  fi
 fi
 
 # We need this line to ensure that data has the correct rights
-if [ "$(stat -c %U:%G ${GEOSERVER_DATA_DIR})" != "tomcat:tomcat" ]; then
-  chown -R tomcat:tomcat "${GEOSERVER_DATA_DIR}"
+if [ "$(stat -c %U:%G ${GEOSERVER_DATA_DIR})" != "ubuntu:ubuntu" ]; then
+  chown -R ubuntu:ubuntu "${GEOSERVER_DATA_DIR}"
 fi
 
 # Install extensions
 find "${GEOSERVER_EXT_DIR}" -mindepth 2 -maxdepth 2 -type f -iname '*.jar' \
- -exec install -o tomcat -g tomcat -p '{}' /usr/local/geoserver/WEB-INF/lib \;
+ -exec install -o ubuntu -g ubuntu -p '{}' /usr/local/geoserver/WEB-INF/lib \;
 
 # https://unix.stackexchange.com/questions/132663/how-do-i-drop-root-privileges-in-shell-scripts
 # http://jdebp.info/FGA/dont-abuse-su-for-dropping-privileges.html
 # --inh-caps=-all results in an error on some systems (setpriv: libcap-ng is too old for "all" caps)
 # get a list of all capabilities, prefix with '-', make a one line ',' sep list & remove the last ',':
 all_caps=$(setpriv --list-caps | sed -e 's/^/-/' | tr '\n' ',' | sed -e 's/,$//')
-command="setpriv --reuid=tomcat --regid=tomcat --init-groups --inh-caps=${all_caps}"
+command="setpriv --reuid=ubuntu --regid=ubuntu --init-groups --inh-caps=${all_caps}"
 command="${command} /usr/local/tomcat/bin/catalina.sh run"
 
 exec ${command}

--- a/2.24.5/Dockerfile
+++ b/2.24.5/Dockerfile
@@ -36,11 +36,10 @@ ENV CATALINA_OPTS "-server -Djava.awt.headless=true \
 	-Xms128m -Xmx1560m -XX:NewSize=48m \
 	-DGEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR}"
 
-# Create tomcat user to avoid root access. 
-RUN addgroup --gid 1099 tomcat && useradd -m -u 1099 -g tomcat tomcat \
-    && chown -R tomcat:tomcat . \
-    && chown -R tomcat:tomcat ${GEOSERVER_DATA_DIR} \
-    && chown -R tomcat:tomcat ${GEOSERVER_INSTALL_DIR}
+# Use default ubuntu user (1000:1000) to avoid root access.
+RUN chown -R ubuntu:ubuntu . \
+    && chown -R ubuntu:ubuntu ${GEOSERVER_DATA_DIR} \
+    && chown -R ubuntu:ubuntu ${GEOSERVER_INSTALL_DIR}
 
 # index.html is used for health check; ensure build fails early if not present
 RUN cat ${GEOSERVER_INSTALL_DIR}/index.html

--- a/2.24.5/start.sh
+++ b/2.24.5/start.sh
@@ -27,31 +27,41 @@ fi
 
 if [ -n "${CUSTOM_UID}" ]; then
   echo "Using custom UID ${CUSTOM_UID}."
-  usermod -u ${CUSTOM_UID} tomcat
-  find / -xdev -user 1099 -exec chown -h tomcat '{}' +
+  UBUNTU_UID=$(id -u "ubuntu" 2>/dev/null)
+  if [ "$UBUNTU_UID" -eq "$CUSTOM_UID" ]; then
+    echo "CUSTOM_UID already in use for ubuntu user. Nothing to do."
+  else
+    usermod -u ${CUSTOM_UID} ubuntu
+    find / -xdev -user 1000 -exec chown -h ubuntu '{}' +
+  fi
 fi
 
 if [ -n "${CUSTOM_GID}" ]; then
   echo "Using custom GID ${CUSTOM_GID}."
-  groupmod -g ${CUSTOM_GID} tomcat
-  find / -xdev -group 1099 -exec chgrp -h tomcat '{}' +
+  UBUNTU_GID=$(id -g "ubuntu" 2>/dev/null)
+  if [ "$UBUNTU_GID" -eq "$CUSTOM_GID" ]; then
+    echo "CUSTOM_GID already in use for ubuntu user. Nothing to do."
+  else
+    groupmod -g ${CUSTOM_GID} ubuntu
+    find / -xdev -group 1000 -exec chgrp -h ubuntu '{}' +
+  fi
 fi
 
 # We need this line to ensure that data has the correct rights
-if [ "$(stat -c %U:%G ${GEOSERVER_DATA_DIR})" != "tomcat:tomcat" ]; then
-  chown -R tomcat:tomcat "${GEOSERVER_DATA_DIR}"
+if [ "$(stat -c %U:%G ${GEOSERVER_DATA_DIR})" != "ubuntu:ubuntu" ]; then
+  chown -R ubuntu:ubuntu "${GEOSERVER_DATA_DIR}"
 fi
 
 # Install extensions
 find "${GEOSERVER_EXT_DIR}" -mindepth 2 -maxdepth 2 -type f -iname '*.jar' \
- -exec install -o tomcat -g tomcat -p '{}' /usr/local/geoserver/WEB-INF/lib \;
+ -exec install -o ubuntu -g ubuntu -p '{}' /usr/local/geoserver/WEB-INF/lib \;
 
 # https://unix.stackexchange.com/questions/132663/how-do-i-drop-root-privileges-in-shell-scripts
 # http://jdebp.info/FGA/dont-abuse-su-for-dropping-privileges.html
 # --inh-caps=-all results in an error on some systems (setpriv: libcap-ng is too old for "all" caps)
 # get a list of all capabilities, prefix with '-', make a one line ',' sep list & remove the last ',':
 all_caps=$(setpriv --list-caps | sed -e 's/^/-/' | tr '\n' ',' | sed -e 's/,$//')
-command="setpriv --reuid=tomcat --regid=tomcat --init-groups --inh-caps=${all_caps}"
+command="setpriv --reuid=ubuntu --regid=ubuntu --init-groups --inh-caps=${all_caps}"
 command="${command} /usr/local/tomcat/bin/catalina.sh run"
 
 exec ${command}

--- a/2.25.6/Dockerfile
+++ b/2.25.6/Dockerfile
@@ -41,7 +41,6 @@ RUN chown -R ubuntu:ubuntu . \
     && chown -R ubuntu:ubuntu ${GEOSERVER_DATA_DIR} \
     && chown -R ubuntu:ubuntu ${GEOSERVER_INSTALL_DIR}
 
-
 # index.html is used for health check; ensure build fails early if not present
 RUN cat ${GEOSERVER_INSTALL_DIR}/index.html
 

--- a/2.25.6/Dockerfile
+++ b/2.25.6/Dockerfile
@@ -36,11 +36,11 @@ ENV CATALINA_OPTS "-server -Djava.awt.headless=true \
 	-Xms128m -Xmx1560m -XX:NewSize=48m \
 	-DGEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR}"
 
-# Create tomcat user to avoid root access. 
-RUN addgroup --gid 1099 tomcat && useradd -m -u 1099 -g tomcat tomcat \
-    && chown -R tomcat:tomcat . \
-    && chown -R tomcat:tomcat ${GEOSERVER_DATA_DIR} \
-    && chown -R tomcat:tomcat ${GEOSERVER_INSTALL_DIR}
+# Use default ubuntu user (1000:1000) to avoid root access.
+RUN chown -R ubuntu:ubuntu . \
+    && chown -R ubuntu:ubuntu ${GEOSERVER_DATA_DIR} \
+    && chown -R ubuntu:ubuntu ${GEOSERVER_INSTALL_DIR}
+
 
 # index.html is used for health check; ensure build fails early if not present
 RUN cat ${GEOSERVER_INSTALL_DIR}/index.html

--- a/2.25.6/start.sh
+++ b/2.25.6/start.sh
@@ -27,31 +27,41 @@ fi
 
 if [ -n "${CUSTOM_UID}" ]; then
   echo "Using custom UID ${CUSTOM_UID}."
-  usermod -u ${CUSTOM_UID} tomcat
-  find / -xdev -user 1099 -exec chown -h tomcat '{}' +
+  UBUNTU_UID=$(id -u "ubuntu" 2>/dev/null)
+  if [ "$UBUNTU_UID" -eq "$CUSTOM_UID" ]; then
+    echo "CUSTOM_UID already in use for ubuntu user. Nothing to do."
+  else
+    usermod -u ${CUSTOM_UID} ubuntu
+    find / -xdev -user 1000 -exec chown -h ubuntu '{}' +
+  fi
 fi
 
 if [ -n "${CUSTOM_GID}" ]; then
   echo "Using custom GID ${CUSTOM_GID}."
-  groupmod -g ${CUSTOM_GID} tomcat
-  find / -xdev -group 1099 -exec chgrp -h tomcat '{}' +
+  UBUNTU_GID=$(id -g "ubuntu" 2>/dev/null)
+  if [ "$UBUNTU_GID" -eq "$CUSTOM_GID" ]; then
+    echo "CUSTOM_GID already in use for ubuntu user. Nothing to do."
+  else
+    groupmod -g ${CUSTOM_GID} ubuntu
+    find / -xdev -group 1000 -exec chgrp -h ubuntu '{}' +
+  fi
 fi
 
 # We need this line to ensure that data has the correct rights
-if [ "$(stat -c %U:%G ${GEOSERVER_DATA_DIR})" != "tomcat:tomcat" ]; then
-  chown -R tomcat:tomcat "${GEOSERVER_DATA_DIR}"
+if [ "$(stat -c %U:%G ${GEOSERVER_DATA_DIR})" != "ubuntu:ubuntu" ]; then
+  chown -R ubuntu:ubuntu "${GEOSERVER_DATA_DIR}"
 fi
 
 # Install extensions
 find "${GEOSERVER_EXT_DIR}" -mindepth 2 -maxdepth 2 -type f -iname '*.jar' \
- -exec install -o tomcat -g tomcat -p '{}' /usr/local/geoserver/WEB-INF/lib \;
+ -exec install -o ubuntu -g ubuntu -p '{}' /usr/local/geoserver/WEB-INF/lib \;
 
 # https://unix.stackexchange.com/questions/132663/how-do-i-drop-root-privileges-in-shell-scripts
 # http://jdebp.info/FGA/dont-abuse-su-for-dropping-privileges.html
 # --inh-caps=-all results in an error on some systems (setpriv: libcap-ng is too old for "all" caps)
 # get a list of all capabilities, prefix with '-', make a one line ',' sep list & remove the last ',':
 all_caps=$(setpriv --list-caps | sed -e 's/^/-/' | tr '\n' ',' | sed -e 's/,$//')
-command="setpriv --reuid=tomcat --regid=tomcat --init-groups --inh-caps=${all_caps}"
+command="setpriv --reuid=ubuntu --regid=ubuntu --init-groups --inh-caps=${all_caps}"
 command="${command} /usr/local/tomcat/bin/catalina.sh run"
 
 exec ${command}

--- a/2.26.2/Dockerfile
+++ b/2.26.2/Dockerfile
@@ -36,11 +36,10 @@ ENV CATALINA_OPTS "-server -Djava.awt.headless=true \
 	-Xms128m -Xmx1560m -XX:NewSize=48m \
 	-DGEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR}"
 
-# Create tomcat user to avoid root access. 
-RUN addgroup --gid 1099 tomcat && useradd -m -u 1099 -g tomcat tomcat \
-    && chown -R tomcat:tomcat . \
-    && chown -R tomcat:tomcat ${GEOSERVER_DATA_DIR} \
-    && chown -R tomcat:tomcat ${GEOSERVER_INSTALL_DIR}
+# Use default ubuntu user (1000:1000) to avoid root access.
+RUN chown -R ubuntu:ubuntu . \
+    && chown -R ubuntu:ubuntu ${GEOSERVER_DATA_DIR} \
+    && chown -R ubuntu:ubuntu ${GEOSERVER_INSTALL_DIR} \
 
 # index.html is used for health check; ensure build fails early if not present
 RUN cat ${GEOSERVER_INSTALL_DIR}/index.html

--- a/2.26.2/start.sh
+++ b/2.26.2/start.sh
@@ -27,31 +27,41 @@ fi
 
 if [ -n "${CUSTOM_UID}" ]; then
   echo "Using custom UID ${CUSTOM_UID}."
-  usermod -u ${CUSTOM_UID} tomcat
-  find / -xdev -user 1099 -exec chown -h tomcat '{}' +
+  UBUNTU_UID=$(id -u "ubuntu" 2>/dev/null)
+  if [ "$UBUNTU_UID" -eq "$CUSTOM_UID" ]; then
+    echo "CUSTOM_UID already in use for ubuntu user. Nothing to do."
+  else
+    usermod -u ${CUSTOM_UID} ubuntu
+    find / -xdev -user 1000 -exec chown -h ubuntu '{}' +
+  fi
 fi
 
 if [ -n "${CUSTOM_GID}" ]; then
   echo "Using custom GID ${CUSTOM_GID}."
-  groupmod -g ${CUSTOM_GID} tomcat
-  find / -xdev -group 1099 -exec chgrp -h tomcat '{}' +
+  UBUNTU_GID=$(id -g "ubuntu" 2>/dev/null)
+  if [ "$UBUNTU_GID" -eq "$CUSTOM_GID" ]; then
+    echo "CUSTOM_GID already in use for ubuntu user. Nothing to do."
+  else
+    groupmod -g ${CUSTOM_GID} ubuntu
+    find / -xdev -group 1000 -exec chgrp -h ubuntu '{}' +
+  fi
 fi
 
 # We need this line to ensure that data has the correct rights
-if [ "$(stat -c %U:%G ${GEOSERVER_DATA_DIR})" != "tomcat:tomcat" ]; then
-  chown -R tomcat:tomcat "${GEOSERVER_DATA_DIR}"
+if [ "$(stat -c %U:%G ${GEOSERVER_DATA_DIR})" != "ubuntu:ubuntu" ]; then
+  chown -R ubuntu:ubuntu "${GEOSERVER_DATA_DIR}"
 fi
 
 # Install extensions
 find "${GEOSERVER_EXT_DIR}" -mindepth 2 -maxdepth 2 -type f -iname '*.jar' \
- -exec install -o tomcat -g tomcat -p '{}' /usr/local/geoserver/WEB-INF/lib \;
+ -exec install -o ubuntu -g ubuntu -p '{}' /usr/local/geoserver/WEB-INF/lib \;
 
 # https://unix.stackexchange.com/questions/132663/how-do-i-drop-root-privileges-in-shell-scripts
 # http://jdebp.info/FGA/dont-abuse-su-for-dropping-privileges.html
 # --inh-caps=-all results in an error on some systems (setpriv: libcap-ng is too old for "all" caps)
 # get a list of all capabilities, prefix with '-', make a one line ',' sep list & remove the last ',':
 all_caps=$(setpriv --list-caps | sed -e 's/^/-/' | tr '\n' ',' | sed -e 's/,$//')
-command="setpriv --reuid=tomcat --regid=tomcat --init-groups --inh-caps=${all_caps}"
+command="setpriv --reuid=ubuntu --regid=ubuntu --init-groups --inh-caps=${all_caps}"
 command="${command} /usr/local/tomcat/bin/catalina.sh run"
 
 exec ${command}


### PR DESCRIPTION
Configura usuario ubuntu por defecto, ya que la imagen base lo trae y si se usaba `CUSTOM_UID` a 1000, no lo usaba al ya existir.

Se ha cambiado un poco la lógica para usar `UID` y `GID`, si ya lo tiene, simplemente no hace nada.

De momento aplica sólo a la 2.25, si lo ves bien lo llevo al resto.